### PR TITLE
Add Cloudflare Turnstile CAPTCHA provider add-on

### DIFF
--- a/src/addons/AxCF/Turnstile/CHANGELOG.md
+++ b/src/addons/AxCF/Turnstile/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.0.0 - 2024-06-07
+- Initial release with Cloudflare Turnstile CAPTCHA provider for XenForo 2.

--- a/src/addons/AxCF/Turnstile/Captcha/Turnstile.php
+++ b/src/addons/AxCF/Turnstile/Captcha/Turnstile.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace AxCF\Turnstile\Captcha;
+
+use XF\Captcha\AbstractCaptcha;
+use XF\Util\Json;
+use function in_array;
+use function is_array;
+use function json_encode;
+
+class Turnstile extends AbstractCaptcha
+{
+    protected const VERIFY_ENDPOINT = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+    protected const REQUEST_TIMEOUT = 5.0;
+
+    public function isAvailable(): bool
+    {
+        $config = $this->getConfig();
+
+        return !empty($config['siteKey']) && !empty($config['secretKey']);
+    }
+
+    protected function renderInternal(array $context): string
+    {
+        $config = $this->getConfig();
+
+        if (empty($config['siteKey']))
+        {
+            return '';
+        }
+
+        $theme = $config['theme'] ?? 'auto';
+        if (!in_array($theme, ['auto', 'light', 'dark'], true))
+        {
+            $theme = 'auto';
+        }
+
+        $size = $config['size'] ?? 'normal';
+        if (!in_array($size, ['normal', 'compact'], true))
+        {
+            $size = 'normal';
+        }
+
+        $params = [
+            'siteKey' => $config['siteKey'],
+            'theme' => $theme,
+            'size' => $size,
+            'context' => $context
+        ];
+
+        return $this->renderer('captcha_turnstile', $params);
+    }
+
+    public function isValid(): bool
+    {
+        $config = $this->getConfig();
+
+        if (empty($config['siteKey']) || empty($config['secretKey']))
+        {
+            return false;
+        }
+
+        $request = $this->app->request();
+        $token = $request->filterSingle('cf-turnstile-response', 'str');
+
+        if ($token === '')
+        {
+            return false;
+        }
+
+        $formParams = [
+            'secret' => $config['secretKey'],
+            'response' => $token
+        ];
+
+        $remoteIp = $request->getIp();
+        if ($remoteIp)
+        {
+            $formParams['remoteip'] = $remoteIp;
+        }
+
+        $client = $this->app->http()->client();
+
+        try
+        {
+            $response = $client->post(self::VERIFY_ENDPOINT, [
+                'form_params' => $formParams,
+                'timeout' => self::REQUEST_TIMEOUT
+            ]);
+        }
+        catch (\Throwable $e)
+        {
+            \XF::logException($e, false, '[AxCF Turnstile] Verification request failed: ');
+            return false;
+        }
+
+        $statusCode = $response->getStatusCode();
+        if ($statusCode !== 200)
+        {
+            \XF::logError('[AxCF Turnstile] Unexpected verification status code: ' . $statusCode);
+            return false;
+        }
+
+        $responseBody = (string) $response->getBody();
+
+        try
+        {
+            $data = Json::decode($responseBody, true);
+        }
+        catch (\Throwable $e)
+        {
+            \XF::logException($e, false, '[AxCF Turnstile] Invalid verification response: ');
+            return false;
+        }
+
+        if (!is_array($data))
+        {
+            return false;
+        }
+
+        if (!empty($data['success']))
+        {
+            return true;
+        }
+
+        if (!empty($data['error-codes']))
+        {
+            $message = '[AxCF Turnstile] Verification failed: ' . json_encode($data['error-codes']);
+            \XF::logError($message);
+        }
+
+        return false;
+    }
+
+    public function getTypeIconClass(): string
+    {
+        return 'fa-shield-halved';
+    }
+
+    protected function getConfig(): array
+    {
+        $config = $this->app->config()['axcfTurnstile'] ?? [];
+
+        return is_array($config) ? $config : [];
+    }
+}

--- a/src/addons/AxCF/Turnstile/LICENSE
+++ b/src/addons/AxCF/Turnstile/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 AxCF
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/addons/AxCF/Turnstile/Listener/Captcha.php
+++ b/src/addons/AxCF/Turnstile/Listener/Captcha.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AxCF\Turnstile\Listener;
+
+use XF\App;
+
+class Captcha
+{
+    public static function captchaTypes(App $app, array &$types): void
+    {
+        $types['axcfTurnstile'] = [
+            'name' => 'Cloudflare Turnstile',
+            'title' => 'Cloudflare Turnstile',
+            'description' => 'Cloudflare Turnstile challenge provided by Cloudflare.',
+            'class' => 'AxCF\\Turnstile\\Captcha\\Turnstile',
+            'icon' => 'fa-shield-halved'
+        ];
+    }
+}

--- a/src/addons/AxCF/Turnstile/README.md
+++ b/src/addons/AxCF/Turnstile/README.md
@@ -1,0 +1,56 @@
+# Cloudflare Turnstile for XenForo 2
+
+## Overview
+Cloudflare Turnstile (AxCF) integrates the [Cloudflare Turnstile](https://www.cloudflare.com/products/turnstile/) CAPTCHA service with XenForo 2, providing a privacy-friendly alternative to traditional CAPTCHAs for registration, login and contact forms.
+
+## Requirements
+- XenForo 2.1 or 2.2
+- PHP 7.4 or newer
+- Valid Cloudflare Turnstile site and secret keys
+
+## Installation
+1. Upload the contents of the `src/addons/AxCF/Turnstile` directory into the same path on your XenForo installation.
+2. Add your Turnstile credentials to `src/config.php`:
+   ```php
+   $config['axcfTurnstile'] = [
+       'siteKey'   => 'your-site-key',
+       'secretKey' => 'your-secret-key',
+       'theme'     => 'auto',
+       'size'      => 'normal',
+   ];
+   ```
+3. In the XenForo Admin Control Panel go to **Add-ons → Install/upgrade** and install **Cloudflare Turnstile**.
+4. Navigate to **Setup → Options → CAPTCHA** and select **Cloudflare Turnstile** as the active CAPTCHA provider.
+5. Test the registration, login and contact forms to confirm the widget renders and validation passes.
+
+## Configuration
+The add-on reads its settings from `src/config.php`. The following options are available:
+
+| Key       | Description                                                  | Default |
+|-----------|--------------------------------------------------------------|---------|
+| `siteKey` | Required. Your Cloudflare Turnstile site key.                | –       |
+| `secretKey` | Required. Your Cloudflare Turnstile secret key.            | –       |
+| `theme`   | Optional. Widget theme: `auto`, `light`, or `dark`.          | `auto`  |
+| `size`    | Optional. Widget size: `normal` or `compact`.                | `normal`|
+
+Changes to `src/config.php` take effect immediately without rebuilding the add-on.
+
+## How it works
+- The public template renders the Turnstile widget container and loads the Cloudflare API with the `defer` attribute.
+- On form submission the add-on validates the `cf-turnstile-response` token server-side via the Cloudflare verification endpoint using XenForo's built-in HTTP client.
+- Verification failures or network errors are logged via `\XF::logException` for easier troubleshooting.
+
+## Troubleshooting
+- **Widget not visible** – Ensure both `siteKey` and `secretKey` are present in `src/config.php`. The provider will not render without them.
+- **Validation always fails** – Verify that the server can reach `https://challenges.cloudflare.com` and that the server clock is accurate.
+- **Timeout errors** – Network issues will log an error. Check your firewall or proxy and confirm outbound HTTPS connections to Cloudflare are allowed.
+- **Using a proxy** – Confirm the real visitor IP is forwarded correctly so Turnstile can validate the request.
+
+## Uninstall
+1. In the XenForo Admin Control Panel, switch to a different CAPTCHA provider.
+2. Uninstall the **Cloudflare Turnstile** add-on from **Add-ons → Installed add-ons**.
+3. Remove the `axcfTurnstile` configuration block from `src/config.php` if no longer required.
+4. Delete the add-on files from the server if desired.
+
+## Changelog & License
+See [`CHANGELOG.md`](CHANGELOG.md) for release history and [`LICENSE`](LICENSE) for licensing details.

--- a/src/addons/AxCF/Turnstile/Setup.php
+++ b/src/addons/AxCF/Turnstile/Setup.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AxCF\Turnstile;
+
+use XF\AddOn\AbstractSetup;
+use XF\AddOn\StepRunnerInstallTrait;
+use XF\AddOn\StepRunnerUpgradeTrait;
+use XF\AddOn\StepRunnerUninstallTrait;
+
+class Setup extends AbstractSetup
+{
+    use StepRunnerInstallTrait;
+    use StepRunnerUpgradeTrait;
+    use StepRunnerUninstallTrait;
+}

--- a/src/addons/AxCF/Turnstile/_output/templates/public/captcha_turnstile.xml
+++ b/src/addons/AxCF/Turnstile/_output/templates/public/captcha_turnstile.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<template title="captcha_turnstile" type="public">
+    <default><![CDATA[
+<xf:js src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer="defer" data-omit-defer="false" />
+
+<div class="cf-turnstile"
+     data-sitekey="{$siteKey}"
+     data-theme="{$theme}"
+     data-size="{$size}"
+     data-language="{$xf.language.language_code}">
+</div>
+    ]]></default>
+</template>

--- a/src/addons/AxCF/Turnstile/addon.json
+++ b/src/addons/AxCF/Turnstile/addon.json
@@ -1,0 +1,22 @@
+{
+    "title": "Cloudflare Turnstile",
+    "description": "Adds Cloudflare Turnstile as a CAPTCHA provider.",
+    "version_id": 1000000,
+    "version_string": "1.0.0",
+    "dev": "AxCF",
+    "require": {
+        "XF": [
+            2010010,
+            "XenForo 2.1.0+"
+        ]
+    },
+    "code_event_listeners": [
+        {
+            "event_id": "captcha_types",
+            "execute_order": 10,
+            "callback_class": "AxCF\\Turnstile\\Listener\\Captcha",
+            "callback_method": "captchaTypes",
+            "active": true
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add an AxCF Cloudflare Turnstile XenForo add-on with event listener registration
- implement widget rendering template and server-side verification logic for Turnstile tokens
- document installation, configuration, changelog, and license for the add-on package

## Testing
- php -l src/addons/AxCF/Turnstile/Captcha/Turnstile.php
- php -l src/addons/AxCF/Turnstile/Listener/Captcha.php
- php -l src/addons/AxCF/Turnstile/Setup.php

------
https://chatgpt.com/codex/tasks/task_e_68dfd59070dc8325a31a105721cf468f